### PR TITLE
*: add travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+dist: xenial
+language: go
+go:
+- "1.12.x"
+go_import_path: github.com/s-urbaniak/prometheus-adapter
+env:
+  - GO111MODULE=on
+cache:
+  directories:
+  - $GOCACHE
+  - $GOPATH/pkg/mod
+services:
+- docker
+jobs:
+  include:
+  - stage: ALL
+    script: make all
+


### PR DESCRIPTION
Simple travis configuration adapted from https://github.com/coreos/prometheus-operator/blob/master/.travis.yml